### PR TITLE
relax aws version constraint to allow for more recent versions of aws provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     - auth:
         password: $DOCKER_PASSWORD
         username: $DOCKER_USERNAME
-      image: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+      image: trussworks/circleci:56d41758666174506ef9a98769e448c63acc2045
     steps:
     - checkout
     - restore_cache:
@@ -18,7 +18,7 @@ jobs:
         paths:
         - ~/.cache/pre-commit
 references:
-  circleci: trussworks/circleci:29ab89fdada1f85c5d8fb685a2c71660f0c5f60c
+  circleci: trussworks/circleci:56d41758666174506ef9a98769e448c63acc2045
 version: 2.1
 workflows:
   validate:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
         keys:
         - pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}
     - run:
-        command: pre-commit run --all-files
+        command: pre-commit run --all-files --show-diff-on-failure
         name: Run pre-commit tests
     - save_cache:
         key: pre-commit-dot-cache-{{ checksum ".pre-commit-config.yaml" }}

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -3,5 +3,6 @@
   "first-header-h1": false,
   "first-line-h1": false,
   "line_length": false,
+  "no-inline-html": false,
   "no-multiple-blanks": false
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-json
       - id: check-merge-conflict
@@ -12,12 +12,12 @@ repos:
       - id: trailing-whitespace
 
   - repo: git://github.com/igorshubovych/markdownlint-cli
-    rev: v0.23.2
+    rev: v0.27.1
     hooks:
       - id: markdownlint
 
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.31.0
+    rev: v1.48.0
     hooks:
       - id: terraform_docs
       - id: terraform_fmt

--- a/README.md
+++ b/README.md
@@ -34,28 +34,47 @@ module "health-notifications" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.13.0 |
-| aws | ~> 3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_role.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cloudwatch\_logs\_retention\_days | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
-| environment | Environment tag, e.g prod. | `any` | n/a | yes |
-| s3\_bucket | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
-| slack\_channel | Slack channel to send alert to | `string` | n/a | yes |
-| ssm\_slack\_webhook\_url | Name of the Slack webhook url parameter in Parameter Store. | `string` | n/a | yes |
-| version\_to\_deploy | The version the Lambda function to deploy. | `string` | n/a | yes |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | Number of days to keep logs in AWS CloudWatch. | `string` | `90` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment tag, e.g prod. | `any` | n/a | yes |
+| <a name="input_s3_bucket"></a> [s3\_bucket](#input\_s3\_bucket) | The name of the S3 bucket used to store the Lambda builds. | `string` | n/a | yes |
+| <a name="input_slack_channel"></a> [slack\_channel](#input\_slack\_channel) | Slack channel to send alert to | `string` | n/a | yes |
+| <a name="input_ssm_slack_webhook_url"></a> [ssm\_slack\_webhook\_url](#input\_ssm\_slack\_webhook\_url) | Name of the Slack webhook url parameter in Parameter Store. | `string` | n/a | yes |
+| <a name="input_version_to_deploy"></a> [version\_to\_deploy](#input\_version\_to\_deploy) | The version the Lambda function to deploy. | `string` | n/a | yes |
 
 ## Outputs
 
-No output.
-
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = ">= 0.13.0"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
Also update pre-commit and address various issues introduced by more recent versions. This adds verbosity to the CI output for pre-commit.