### PR TITLE
fix bug causing double // in aws_iam_policy_document

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "main" {
       "ssm:GetParameter",
     ]
 
-    resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.ssm_slack_webhook_url}"]
+    resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_slack_webhook_url}"]
   }
 }
 


### PR DESCRIPTION
The "/" in SSMAllowRead is causing the SSM permission to 400 auth error out due to invalid resource in permission by creating a double "//" while the actual ssm:GetParameter call is correct. 

arn:aws:ssm:us-west-2:0000000000:parameter//some/paremter/url
instead of 
arn:aws:ssm:us-west-2:0000000000:parameter/some/paremter/url